### PR TITLE
fix: be able to parse hoisting declarers #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-export-restrict",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
## About
closed: #7 
it can parse hoisting declarers.

```js
/** @private */
export const test = {};

function v(){};

export {
  a,
  def,
  aAX,
  bc,
};

/** @private */
function a(){};

/** @private */
class bc {}

export {
  abc,
};

/** @private */
const abc = {};

/** @private */
const def = {};

/** @private */
class aAX {}
```