### PR TITLE
refactor: package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It will be help to manage export declarations for private functions, classes, an
 
 ## Motivation
 In TypeScript and JavaScript, when declarers is defined in a file, it is not possible to manage strictly as a private functions, classes, and variables.  
-Using `eslint-plugin-export-restrict`, you can protect by writing `@private` as a comment like JSDoc and TSDoc, and is able to solve those problems.  
+Using `eslint-plugin-export-restrict`, you can protect by writing `@private` as a comment like JSDoc and TSDoc, and solve those problems.  
 
 ## Installation
 - npm
@@ -25,6 +25,7 @@ Depending on how you configure ESLint, use either Flat Config or eslintrc to con
 
 ```js
 import exportRestrictPlugin from "eslint-plugin-export-restrict";
+// const exportRestrictPlugin = require("eslint-plugin-export-restrict");
 
 export default [
   // other settings...
@@ -32,8 +33,6 @@ export default [
     plugins: {
       "export-restrict": exportRestrictPlugin,
     },
-  },
-  {
     rules: {
       "export-restrict/no-export-private-declare": ["error"],
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-export-restrict",
-  "version": "0.2.1-beta",
+  "version": "0.2.2-beta",
   "files": [
     "dist",
     "src"
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@9.1.0",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
-  "types": "dist/cjs/index.d.cts",
+  "types": "dist/esm/index.d.mts",
   "description": "ESLint Plugin For Restricted Export",
   "scripts": {
     "build": "tsc -p ./src/tsconfig.json",

--- a/src/cjs/rules/exportPrivateDeclareRule.cts
+++ b/src/cjs/rules/exportPrivateDeclareRule.cts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
 import type * as ESTree from "estree";
 
-function exportRestrictFixer<T>(
+function exportPrivateFixer<T>(
   fixer: Rule.RuleFixer,
   targetNode: Rule.Node,
   hint: {
@@ -41,7 +41,7 @@ function exportRestrictFixer<T>(
   return { range: [0, 0], text: "" };
 }
 
-const exportRestrictRule: Rule.RuleModule = {
+const exportPrivateRule: Rule.RuleModule = {
   meta: {
     type: "problem",
     docs: {
@@ -245,7 +245,7 @@ const exportRestrictRule: Rule.RuleModule = {
               loc: declaration.loc,
               message: `private function ${declaration.id.name} cannot export`,
               fix: (fixer) =>
-                exportRestrictFixer<typeof declaration.type>(fixer, node, {
+                exportPrivateFixer<typeof declaration.type>(fixer, node, {
                   declaration,
                 }),
             });
@@ -254,7 +254,7 @@ const exportRestrictRule: Rule.RuleModule = {
               loc: declaration.loc,
               message: `private class ${declaration.id.name} cannot export`,
               fix: (fixer) =>
-                exportRestrictFixer<typeof declaration.type>(fixer, node, {
+                exportPrivateFixer<typeof declaration.type>(fixer, node, {
                   declaration,
                 }),
             });
@@ -272,7 +272,7 @@ const exportRestrictRule: Rule.RuleModule = {
               variableIdentifiers.length === 1 ? variableIdentifiers.map((id) => id.name).toString() + " " : ""
             }cannot export`,
             fix: (fixer) =>
-              exportRestrictFixer<typeof declaration.type>(fixer, node, {
+              exportPrivateFixer<typeof declaration.type>(fixer, node, {
                 declaration,
               }),
           });
@@ -329,7 +329,7 @@ const exportRestrictRule: Rule.RuleModule = {
               names.length === 1 ? names.map((name) => name).toString() + " " : ""
             }cannot export`,
             fix: (fixer) =>
-              exportRestrictFixer<typeof type>(fixer, node, {
+              exportPrivateFixer<typeof type>(fixer, node, {
                 identifier,
               }),
           });
@@ -339,4 +339,4 @@ const exportRestrictRule: Rule.RuleModule = {
   },
 };
 
-module.exports = exportRestrictRule;
+module.exports = exportPrivateRule;

--- a/src/esm/index.mts
+++ b/src/esm/index.mts
@@ -1,5 +1,5 @@
-import { exportRestrictRule } from "./rules/exportPrivateDeclareRule.mjs";
+import { exportPrivateRule } from "./rules/exportPrivateDeclareRule.mjs";
 
 export default {
-  rules: { "no-export-private-declare": exportRestrictRule },
+  rules: { "no-export-private-declare": exportPrivateRule },
 };

--- a/src/esm/rules/exportPrivateDeclareRule.mts
+++ b/src/esm/rules/exportPrivateDeclareRule.mts
@@ -1,7 +1,7 @@
 import type { Rule } from "eslint";
 import type * as ESTree from "estree";
 
-function exportRestrictFixer<T>(
+function exportPrivateFixer<T>(
   fixer: Rule.RuleFixer,
   targetNode: Rule.Node,
   hint: {
@@ -41,7 +41,7 @@ function exportRestrictFixer<T>(
   return { range: [0, 0], text: "" };
 }
 
-const exportRestrictRule: Rule.RuleModule = {
+const exportPrivateRule: Rule.RuleModule = {
   meta: {
     type: "problem",
     docs: {
@@ -245,7 +245,7 @@ const exportRestrictRule: Rule.RuleModule = {
               loc: declaration.loc,
               message: `private function ${declaration.id.name} cannot export`,
               fix: (fixer) =>
-                exportRestrictFixer<typeof declaration.type>(fixer, node, {
+                exportPrivateFixer<typeof declaration.type>(fixer, node, {
                   declaration,
                 }),
             });
@@ -254,7 +254,7 @@ const exportRestrictRule: Rule.RuleModule = {
               loc: declaration.loc,
               message: `private class ${declaration.id.name} cannot export`,
               fix: (fixer) =>
-                exportRestrictFixer<typeof declaration.type>(fixer, node, {
+                exportPrivateFixer<typeof declaration.type>(fixer, node, {
                   declaration,
                 }),
             });
@@ -272,7 +272,7 @@ const exportRestrictRule: Rule.RuleModule = {
               variableIdentifiers.length === 1 ? variableIdentifiers.map((id) => id.name).toString() + " " : ""
             }cannot export`,
             fix: (fixer) =>
-              exportRestrictFixer<typeof declaration.type>(fixer, node, {
+              exportPrivateFixer<typeof declaration.type>(fixer, node, {
                 declaration,
               }),
           });
@@ -329,7 +329,7 @@ const exportRestrictRule: Rule.RuleModule = {
               names.length === 1 ? names.map((name) => name).toString() + " " : ""
             }cannot export`,
             fix: (fixer) =>
-              exportRestrictFixer<typeof type>(fixer, node, {
+              exportPrivateFixer<typeof type>(fixer, node, {
                 identifier,
               }),
           });
@@ -339,4 +339,4 @@ const exportRestrictRule: Rule.RuleModule = {
   },
 };
 
-export { exportRestrictRule };
+export { exportPrivateRule };


### PR DESCRIPTION
## About
- It is able to view Types about installed `[eslint-plugin-export-restrict](https://github.com/tsukuha/eslint-plugin-export-restrict)` using npm.
- refactor: README